### PR TITLE
Add support to smsapi-notifier

### DIFF
--- a/Exception/UnsupportedSchemeException.php
+++ b/Exception/UnsupportedSchemeException.php
@@ -62,6 +62,10 @@ class UnsupportedSchemeException extends LogicException
             'class' => Bridge\Sinch\SinchTransportFactory::class,
             'package' => 'symfony/sinch-notifier',
         ],
+        'smsapi' => [
+            'class' => Bridge\Smsapi\SmsapiTransportFactory::class,
+            'package' => 'symfony/smsapi-notifier',
+        ]
     ];
 
     /**

--- a/Transport.php
+++ b/Transport.php
@@ -19,6 +19,7 @@ use Symfony\Component\Notifier\Bridge\OvhCloud\OvhCloudTransportFactory;
 use Symfony\Component\Notifier\Bridge\RocketChat\RocketChatTransportFactory;
 use Symfony\Component\Notifier\Bridge\Sinch\SinchTransportFactory;
 use Symfony\Component\Notifier\Bridge\Slack\SlackTransportFactory;
+use Symfony\Component\Notifier\Bridge\Smsapi\SmsapiTransportFactory;
 use Symfony\Component\Notifier\Bridge\Telegram\TelegramTransportFactory;
 use Symfony\Component\Notifier\Bridge\Twilio\TwilioTransportFactory;
 use Symfony\Component\Notifier\Exception\UnsupportedSchemeException;
@@ -50,6 +51,7 @@ class Transport
         FirebaseTransportFactory::class,
         SinchTransportFactory::class,
         FreeMobileTransportFactory::class,
+        SmsapiTransportFactory::class,
     ];
 
     private $factories;


### PR DESCRIPTION
Hi,

I created integration to notifier to support polish operators with smsapi.pl service.

smsapi-notifier is here: https://github.com/szepczynski/smsapi-notifier

I've tested integration by using this version of framework-bundle:
https://github.com/szepczynski/framework-bundle

and symfony-notifier in this PR

Can you add support of smsapi-notfier to symfony/symfony-notifier and symfony/framework-bundle? 
